### PR TITLE
Formats issue body for proper markdown rendering

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -52,11 +52,14 @@ export class GitHubService {
     repo: string,
     issue: Issue
   ): Promise<number> {
+    // Replace literal \n with actual newlines for proper markdown formatting
+    const formattedBody = issue.body.replace(/\\n/g, '\n')
+
     const { data } = await this.octokit.issues.create({
       owner,
       repo,
       title: issue.title,
-      body: issue.body,
+      body: formattedBody,
       labels: issue.labels,
       assignees: issue.assignees,
     })


### PR DESCRIPTION
Replaces escaped newline characters (`\n`) with actual newline
characters in the issue body before creating the issue. This
ensures proper markdown formatting in the rendered issue description,
particularly addressing issues arising from old templates.
