### PR TITLE
fix: resolve repository selection failing with 500 error

### DIFF
--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -31,14 +31,30 @@ export async function GET(request: NextRequest) {
     }
 
     const github = new GitHubService(session.accessToken)
-    const repos = await github.getUserRepos()
 
-    return NextResponse.json({ repos })
+    try {
+      const repos = await github.getUserRepos()
+      return NextResponse.json({ repos })
+    } catch (githubError: unknown) {
+      const status = (githubError as { status?: number })?.status
+      console.error("GitHub API error fetching repos:", githubError)
+
+      if (status === 401) {
+        return NextResponse.json(
+          { error: "GitHub token expired. Please sign out and sign in again." },
+          { status: 401 }
+        )
+      }
+      if (status === 403) {
+        return NextResponse.json(
+          { error: "Insufficient GitHub permissions. Please sign out and sign in again to re-authorize." },
+          { status: 403 }
+        )
+      }
+      throw githubError
+    }
   } catch (error) {
-    // Log error server-side only
     console.error("Repository fetch failed:", error)
-
-    // Return sanitized error message
     return NextResponse.json(
       { error: "Failed to fetch repositories" },
       { status: 500 }

--- a/components/repo-selector.tsx
+++ b/components/repo-selector.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { signIn } from "next-auth/react"
 import { Template, BoardType, BoardColumn, PhaseColumnMapping } from "@/types/template"
 import { BOARD_PRESETS, BOARD_TYPE_LABELS } from "@/lib/board-presets"
 
@@ -22,6 +23,7 @@ export function RepoSelector({ template, onClose }: RepoSelectorProps) {
   const [repos, setRepos] = useState<Repository[]>([])
   const [loading, setLoading] = useState(true)
   const [repoError, setRepoError] = useState<string | null>(null)
+  const [isAuthError, setIsAuthError] = useState(false)
   const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null)
   const [generating, setGenerating] = useState(false)
   const [progress, setProgress] = useState({ phase: "", current: 0, total: 0 })
@@ -94,7 +96,12 @@ export function RepoSelector({ template, onClose }: RepoSelectorProps) {
       const response = await fetch("/api/repos")
       const data = await response.json()
       if (!response.ok) {
-        setRepoError(data.error || "Failed to fetch repositories")
+        if (response.status === 401 || response.status === 403) {
+          setIsAuthError(true)
+          setRepoError(data.error || "GitHub token expired. Please sign in again.")
+        } else {
+          setRepoError(data.error || "Failed to fetch repositories")
+        }
         return
       }
       if (data.repos) {
@@ -339,7 +346,15 @@ export function RepoSelector({ template, onClose }: RepoSelectorProps) {
               ) : repoError ? (
                 <div className="text-center py-12">
                   <div className="text-6xl mb-4">⚠️</div>
-                  <p className="text-gray-600 dark:text-gray-400">{repoError}</p>
+                  <p className="text-gray-600 dark:text-gray-400 mb-4">{repoError}</p>
+                  {isAuthError && (
+                    <button
+                      onClick={() => signIn("github")}
+                      className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                    >
+                      Sign in with GitHub
+                    </button>
+                  )}
                 </div>
               ) : repos.length === 0 ? (
                 <div className="text-center py-12">

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -83,10 +83,10 @@ export class GitHubService {
   }
 
   async getUserRepos() {
-    const { data } = await this.octokit.repos.listForAuthenticatedUser({
+    const { data } = await this.octokit.rest.repos.listForAuthenticatedUser({
       sort: "updated",
       per_page: 100,
-      affiliation: "owner",
+      visibility: "all",
     })
     return data
   }


### PR DESCRIPTION
## Summary

- Switch `getUserRepos` to `octokit.rest.repos.listForAuthenticatedUser` (canonical `@octokit/rest` v21 API path) and replace `affiliation: "owner"` with `visibility: "all"` so all accessible repos are returned
- Catch GitHub API 401/403 errors in `/api/repos` and return the correct status code instead of a generic 500
- Return `extendedSession` (not `session`) in the NextAuth session callback so `accessToken` is reliably included
- Show a **"Sign in with GitHub"** button in the repo selector when the token is expired or revoked, instead of a silent "No repositories found"

## Test plan

- [ ] Sign in and open the board creation flow — repositories should load
- [ ] Revoke the GitHub OAuth token and retry — should see an error message with a "Sign in with GitHub" button instead of a blank list
- [ ] Verify no regression on board generation after selecting a repo
